### PR TITLE
perf(db): optimize batch insert with raw SQL for initial load

### DIFF
--- a/web/static/js/core/startup-loader.js
+++ b/web/static/js/core/startup-loader.js
@@ -97,6 +97,7 @@ const LogLynxStartupLoader = {
      * Show the startup loading screen
      */
     showLoadingScreen() {
+        return;
         // Check if loading screen already exists
         let loadingScreen = document.getElementById('startupLoadingScreen');
         if (loadingScreen) {


### PR DESCRIPTION
Add insertSubBatchRaw method for high-throughput initial data loading using raw SQL with ON CONFLICT duplicate handling. Reduce batch size to 50 for improved safety margin under SQLite variable limits. Disable startup loading screen via early return.