### PR TITLE
Remove non-root user configuration from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,6 @@ VOLUME ["/data", "/app/geoip", "/traefik/logs"]
 
 EXPOSE 8080
 
+
 ENTRYPOINT ["/usr/local/bin/loglynx"]
+


### PR DESCRIPTION
The configuration that allowed the image to be executed as a non-root user has been removed. This change would have resulted in breaking changes with regard to the management of permissions in the db folder structure.

Therefore, this change has been postponed for the time being and a revert to the state of the last release has been made.