### PR TITLE
ci: configure docker workflow for cross-architecture builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64
           tags: ${{ env.IMAGE }}:dev-k
 
       - name: Build and push (main -> dev)
@@ -44,6 +45,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64
           tags: ${{ env.IMAGE }}:dev
 
       - name: Build and push (release -> latest and version)
@@ -52,6 +54,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage Dockerfile for LogLynx
-# Builder stage: compiles a static linux/amd64 binary
+# Builder stage: compiles a static binary for the target platform
 FROM golang:1.25.5 AS builder
 
 WORKDIR /src
@@ -12,7 +12,10 @@ RUN go mod download
 COPY . .
 
 # Build the server binary (CGO enabled for sqlite/geoip native deps)
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
+# TARGETPLATFORM and TARGETARCH are automatically set by Docker Buildx
+ARG TARGETPLATFORM
+ARG TARGETARCH
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=$TARGETARCH \
     go build -ldflags "-s -w" -o /out/loglynx ./cmd/server
 
 


### PR DESCRIPTION
Update the GitHub Actions pipeline to generate container images targeting both amd64 and arm64 architectures, expanding hardware compatibility.

Tested via qemu Debian 13 Wheezy aarch64

```
user@arm:~$ uname -a
Linux arm 6.12.57+deb13-arm64 #1 SMP Debian 6.12.57-1 (2025-11-05) aarch64 GNU/Linux
user@arm:~$ uname -m
aarch64
user@arm:~$ lscpu
Architecture:                aarch64
  CPU op-mode(s):            32-bit, 64-bit
  Byte Order:                Little Endian
CPU(s):                      2
  On-line CPU(s) list:       0,1
Vendor ID:                   ARM
  Model name:                Cortex-A57
```
I was able to pull the docker image from my own [docker hub repo](https://hub.docker.com/repository/docker/droddo/loglynx/tags) and start loglynx that processed entries correctly