### PR TITLE
feat: add support for Caddy access logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ TRAEFIK_LOG_PATH=traefik/logs/access.log
 # clf: expects Common Log Format (text) only
 TRAEFIK_LOG_FORMAT=auto
 
+# Path to Caddy access log file (JSON format)
+CADDY_LOG_PATH=caddy/logs/access.log
+
 # Auto-discover log files in directories
 LOG_AUTO_DISCOVER=true
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # LogLynx 🦁📊
 
-**Advanced Log Analytics Platform for Traefik and Beyond**
+**Advanced Log Analytics Platform for Traefik, Caddy, and Beyond**
 
-LogLynx is a high-performance (less than 50 MB of RAM), real-time log analytics platform designed to provide deep insights into your web traffic. Built with Go and optimized for Traefik reverse proxy logs, it offers a beautiful dark-themed dashboard and comprehensive REST API.
+LogLynx is a high-performance (less than 50 MB of RAM), real-time log analytics platform designed to provide deep insights into your web traffic. Built with Go and optimized for reverse proxy logs (Traefik and Caddy), it offers a beautiful dark-themed dashboard and comprehensive REST API.
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 ![Go Version](https://img.shields.io/badge/go-%3E%3D1.21-blue.svg)
@@ -11,6 +11,7 @@ LogLynx is a high-performance (less than 50 MB of RAM), real-time log analytics 
 > **📚 Important Documentation**
 >
 > - **[Traefik Setup Guide](../../wiki/Traefik)** - Recommended Traefik configuration for optimal LogLynx performance and complete field capture (for the [pangolin quick installation](https://docs.pangolin.net/self-host/quick-install) no additional configuration is required for Traefik).
+> - **[Caddy Setup Guide](../../wiki/Caddy)** - Caddy configuration for JSON access log format with LogLynx
 > - **[Deduplication System](../../wiki/Deduplication-System)** - Learn how LogLynx prevents duplicate log entries and handles various scenarios (log rotation, crashes, re-imports)
 
 <img width="1920" height="1080" alt="LogLynx-Overview-Demo" src="img/LogLynx-Overview-Demo.png" />
@@ -26,14 +27,15 @@ LogLynx is a high-performance (less than 50 MB of RAM), real-time log analytics 
 - 🔌 **REST API** - Full-featured API for integrations
 - 📱 **Device Analytics** - Browser, OS, and device type detection
 - 🌐 **GeoIP Enrichment** - Country, city, and ASN information
-- 🔄 **Auto-Discovery** - Automatically detects Traefik log files
+- 🔄 **Auto-Discovery** - Automatically detects Traefik and Caddy log files
+- 🔌 **Multi-Parser Support** - Works with Traefik and Caddy reverse proxy logs
 
 ## 🚀 Quick Start
 
 ### Prerequisites
 
 - Go 1.25 or higher
-- Traefik access logs (optional for initial setup)
+- Traefik or Caddy access logs (optional for initial setup)
 
 ### Standalone installation
 
@@ -174,6 +176,12 @@ GEOIP_ASN_DB=geoip/GeoLite2-ASN.mmdb
 # ================================
 # Path to Traefik access log file
 TRAEFIK_LOG_PATH=traefik/logs/access.log
+
+# Path to Caddy access log file (JSON format)
+CADDY_LOG_PATH=caddy/logs/access.log
+
+# Auto-discovery of log files (default: true)
+LOG_AUTO_DISCOVER=true
 ```
 
 
@@ -196,6 +204,35 @@ accessLog:
   format: json  # JSON format recommended
 ```
 
+### Caddy Log Format
+
+LogLynx requires Caddy's JSON access log format. Configure Caddy with:
+
+```caddyfile
+{
+    log {
+        output file /var/log/caddy/access.log
+        format json
+        level INFO
+    }
+}
+
+# Or per-site configuration:
+example.com {
+    log {
+        output file /var/log/caddy/access.log
+        format json
+    }
+    reverse_proxy localhost:8080
+}
+```
+
+**Important Notes for Caddy:**
+- JSON format is **required** (default CLF/common log format is not supported)
+- Cookie headers are stored as-is - configure redaction in Caddy if needed
+- LogLynx automatically extracts client IP from `client_ip`, `remote_ip`, or `X-Forwarded-For`
+- TLS information (version, cipher suite) is automatically converted from numeric codes
+
 ## 📦 Project Structure
 
 ```
@@ -204,9 +241,10 @@ loglynx/
 ├── internal/
 │   ├── api/            # HTTP server and handlers
 │   ├── database/       # Database models and repositories
+│   ├── discovery/      # Log file auto-discovery
 │   ├── enrichment/     # GeoIP enrichment
 │   ├── ingestion/      # Log file processing
-│   ├── parser/         # Log format parsers
+│   ├── parser/         # Log format parsers (Traefik, Caddy)
 │   └── realtime/       # Real-time metrics
 ├── web/
 │   ├── static/         # CSS, JavaScript, images
@@ -252,6 +290,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 🙏 Acknowledgments
 
 - [Traefik](https://traefik.io/) - Modern HTTP reverse proxy
+- [Caddy](https://caddyserver.com/) - Fast and extensible multi-platform HTTP server
 - [MaxMind GeoLite2](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data) - GeoIP databases
 - [DataTables](https://datatables.net/) - Table plugin for jQuery
 - [Chart.js](https://www.chartjs.org/) - JavaScript charting

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2026 Kolin
+// # Copyright (c) 2026 Kolin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-//
 package config
 
 import (
@@ -81,6 +80,7 @@ type GeoIPConfig struct {
 type LogSourcesConfig struct {
 	TraefikLogPath      string
 	TraefikLogFormat    string // auto, json, clf
+	CaddyLogPath        string
 	AutoDiscover        bool
 	InitialImportDays   int  // Only import last N days on first run (0 = import all)
 	InitialImportEnable bool // Enable initial import limiting
@@ -134,6 +134,7 @@ func Load() (*Config, error) {
 		LogSources: LogSourcesConfig{
 			TraefikLogPath:      getEnv("TRAEFIK_LOG_PATH", "traefik/logs/access.log"),
 			TraefikLogFormat:    getEnv("TRAEFIK_LOG_FORMAT", "auto"),
+			CaddyLogPath:        getEnv("CADDY_LOG_PATH", "caddy/logs/access.log"),
 			AutoDiscover:        getEnvAsBool("LOG_AUTO_DISCOVER", true),
 			InitialImportDays:   getEnvAsInt("INITIAL_IMPORT_DAYS", 60),
 			InitialImportEnable: getEnvAsBool("INITIAL_IMPORT_ENABLE", true),

--- a/internal/discovery/caddy.go
+++ b/internal/discovery/caddy.go
@@ -1,0 +1,141 @@
+package discovery
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"loglynx/internal/database/models"
+	"os"
+	"strings"
+
+	"github.com/pterm/pterm"
+)
+
+// CaddyDetector detects Caddy log files
+type CaddyDetector struct {
+	logger         *pterm.Logger
+	configuredPath string
+	autoDiscover   bool
+}
+
+// NewCaddyDetector creates a new Caddy detector
+func NewCaddyDetector(logger *pterm.Logger) ServiceDetector {
+	autoDiscover := true
+	if autoDiscoverEnv := os.Getenv("LOG_AUTO_DISCOVER"); autoDiscoverEnv != "" {
+		autoDiscover = autoDiscoverEnv == "true"
+	}
+
+	return &CaddyDetector{
+		logger:         logger,
+		configuredPath: os.Getenv("CADDY_LOG_PATH"),
+		autoDiscover:   autoDiscover,
+	}
+}
+
+// Name returns the detector name
+func (d *CaddyDetector) Name() string {
+	return "caddy"
+}
+
+// Detect discovers Caddy log sources
+func (d *CaddyDetector) Detect() ([]*models.LogSource, error) {
+	sources := []*models.LogSource{}
+
+	paths := []string{}
+
+	// Priority 1: Use CADDY_LOG_PATH if set and valid
+	if d.configuredPath != "" {
+		if fileInfo, err := os.Stat(d.configuredPath); err == nil && !fileInfo.IsDir() {
+			paths = append(paths, d.configuredPath)
+			d.logger.Info("Using configured CADDY_LOG_PATH", d.logger.Args("path", d.configuredPath))
+		} else {
+			d.logger.Warn("Configured CADDY_LOG_PATH is invalid", d.logger.Args("path", d.configuredPath, "error", err))
+		}
+	} else if d.autoDiscover {
+		// Priority 2: Auto-discovery
+		d.logger.Info("Auto-discovering Caddy log files...")
+		paths = append(paths,
+			"caddy/logs/access.log",
+			"/var/log/caddy/access.log",
+			"/var/log/caddy/access.json",
+		)
+	}
+
+	// Validate each path
+	for _, path := range paths {
+		fileInfo, err := os.Stat(path)
+		if err != nil {
+			d.logger.Debug("Caddy log path not found", d.logger.Args("path", path))
+			continue
+		}
+
+		if fileInfo.IsDir() {
+			d.logger.Debug("Path is a directory, skipping", d.logger.Args("path", path))
+			continue
+		}
+
+		if fileInfo.Size() == 0 {
+			d.logger.Debug("Log file is empty, skipping", d.logger.Args("path", path))
+			continue
+		}
+
+		if isCaddyFormat(path, d.logger) {
+			d.logger.Info("Caddy log source detected", d.logger.Args("path", path))
+			sources = append(sources, &models.LogSource{
+				Name:       generateCaddySourceName(path),
+				Path:       path,
+				ParserType: "caddy",
+			})
+			break // Only use first valid source
+		}
+	}
+
+	if len(sources) == 0 {
+		d.logger.Info("No Caddy log sources detected")
+	}
+
+	return sources, nil
+}
+
+// isCaddyFormat checks if a file contains Caddy JSON logs
+func isCaddyFormat(path string, logger *pterm.Logger) bool {
+	file, err := os.Open(path)
+	if err != nil {
+		logger.Debug("Failed to open file", logger.Args("path", path, "error", err))
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	if scanner.Scan() {
+		line := scanner.Text()
+
+		// Try to parse as JSON
+		var logEntry map[string]any
+		if err := json.Unmarshal([]byte(line), &logEntry); err == nil {
+			// Check for Caddy-specific fields
+			loggerField, hasLogger := logEntry["logger"].(string)
+			_, hasRequest := logEntry["request"]
+
+			if hasLogger && strings.HasPrefix(loggerField, "http.log.access") && hasRequest {
+				logger.Debug("File matches Caddy format", logger.Args("path", path))
+				return true
+			}
+		}
+	}
+
+	logger.Debug("File does not match Caddy format", logger.Args("path", path))
+	return false
+}
+
+// generateCaddySourceName generates a unique source name from the file path
+func generateCaddySourceName(path string) string {
+	// Split path and get filename
+	pathSplit := strings.Split(strings.ReplaceAll(path, "\\", "/"), "/")
+	fileNameExtension := pathSplit[len(pathSplit)-1]
+
+	// Remove extension
+	fileName := strings.Split(fileNameExtension, ".")[0]
+
+	return fmt.Sprintf("caddy-%s", fileName)
+}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2026 Kolin
+// # Copyright (c) 2026 Kolin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-//
 package discovery
 
 import (
@@ -44,6 +43,7 @@ func NewEngine(repo repositories.LogSourceRepository, logger *pterm.Logger) *Eng
         repo: repo,
         detectors: []ServiceDetector{
             NewTraefikDetector(logger),
+            NewCaddyDetector(logger),
         },
     }
 }

--- a/internal/parser/caddy/models.go
+++ b/internal/parser/caddy/models.go
@@ -1,0 +1,80 @@
+package caddy
+
+import "time"
+
+// CaddyRequestEvent represents a parsed Caddy access log entry.
+// This struct maps Caddy's JSON log format to LogLynx's HTTPRequest model.
+type CaddyRequestEvent struct {
+	// Core fields
+	Timestamp  time.Time
+	SourceName string
+
+	// Client info
+	ClientIP   string
+	ClientPort int
+	ClientUser string
+
+	// Request info
+	Method        string
+	Protocol      string
+	Host          string
+	Path          string
+	QueryString   string
+	RequestLength int64
+	RequestScheme string
+
+	// Response info
+	StatusCode          int
+	ResponseSize        int64
+	ResponseTimeMs      float64
+	ResponseContentType string
+
+	// Detailed timing
+	Duration               int64   // Nanoseconds
+	StartUTC               string  // RFC3339Nano for hash calculation
+	UpstreamResponseTimeMs float64
+	RetryAttempts          int
+	RequestsTotal          int
+
+	// Headers
+	UserAgent string
+	Referer   string
+
+	// Proxy/Upstream info
+	BackendName         string
+	BackendURL          string
+	RouterName          string
+	UpstreamStatus      int
+	UpstreamContentType string
+	ClientHostname      string
+
+	// TLS info
+	TLSVersion    string
+	TLSCipher     string
+	TLSServerName string
+
+	// Tracing
+	RequestID string
+	TraceID   string
+
+	// GeoIP (populated later by enrichment)
+	GeoCountry string
+	GeoCity    string
+	GeoLat     float64
+	GeoLon     float64
+	ASN        int
+	ASNOrg     string
+
+	// Extensibility - Caddy-specific data stored as JSON
+	ProxyMetadata string
+}
+
+// GetTimestamp implements the parser.Event interface
+func (e *CaddyRequestEvent) GetTimestamp() time.Time {
+	return e.Timestamp
+}
+
+// GetSourceName implements the parser.Event interface
+func (e *CaddyRequestEvent) GetSourceName() string {
+	return e.SourceName
+}

--- a/internal/parser/caddy/parser.go
+++ b/internal/parser/caddy/parser.go
@@ -1,0 +1,358 @@
+package caddy
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pterm/pterm"
+)
+
+// Parser implements the LogParser interface for Caddy access logs
+type Parser struct {
+	logger *pterm.Logger
+}
+
+// NewParser creates a new Caddy parser instance
+func NewParser(logger *pterm.Logger) *Parser {
+	return &Parser{
+		logger: logger,
+	}
+}
+
+// Name returns the parser name
+func (p *Parser) Name() string {
+	return "caddy"
+}
+
+// CanParse checks if the log line is in Caddy JSON format
+func (p *Parser) CanParse(line string) bool {
+	if len(line) == 0 || line[0] != '{' {
+		return false
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return false
+	}
+
+	// Check for Caddy-specific fields
+	logger, hasLogger := raw["logger"].(string)
+	_, hasRequest := raw["request"]
+
+	// Caddy access logs have logger starting with "http.log.access"
+	return hasLogger && strings.HasPrefix(logger, "http.log.access") && hasRequest
+}
+
+// Parse parses a Caddy JSON log line into a CaddyRequestEvent
+func (p *Parser) Parse(line string) (*CaddyRequestEvent, error) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	// Extract timestamp (Unix float)
+	ts := getFloat64(raw, "ts")
+	if ts == 0 {
+		return nil, fmt.Errorf("missing or invalid timestamp")
+	}
+	timestamp := parseUnixTimestamp(ts)
+
+	// Extract request object
+	request, ok := raw["request"].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("missing request object")
+	}
+
+	// Extract client IP with fallback logic
+	clientIP := getStringFromMap(request, "client_ip")
+	if clientIP == "" {
+		clientIP = getStringFromMap(request, "remote_ip")
+	}
+	if clientIP == "" {
+		// Try X-Forwarded-For header
+		headers, _ := request["headers"].(map[string]any)
+		clientIP = extractHeaderArray(headers, "X-Forwarded-For")
+	}
+
+	// Extract client port
+	clientPort := getIntFromMap(request, "remote_port")
+
+	// Extract URI and split into path + query
+	uri := getStringFromMap(request, "uri")
+	path, queryString := splitURI(uri)
+
+	// Extract method, protocol, host
+	method := getStringFromMap(request, "method")
+	protocol := getStringFromMap(request, "proto")
+	host := getStringFromMap(request, "host")
+
+	// Determine request scheme from TLS presence
+	tls, hasTLS := request["tls"].(map[string]any)
+	requestScheme := "http"
+	if hasTLS {
+		requestScheme = "https"
+	}
+
+	// Extract TLS info
+	tlsVersion := ""
+	tlsCipher := ""
+	tlsServerName := ""
+	if hasTLS {
+		tlsVersion = convertTLSVersion(getIntFromMap(tls, "version"))
+		tlsCipher = convertTLSCipher(getIntFromMap(tls, "cipher_suite"))
+		tlsServerName = getStringFromMap(tls, "server_name")
+	}
+
+	// Extract status code, response size, duration
+	statusCode := getInt(raw, "status")
+	responseSize := getInt64(raw, "size")
+	duration := getFloat64(raw, "duration")
+	responseTimeMs := duration * 1000 // Convert to milliseconds
+
+	// Extract response content type
+	responseContentType := extractResponseHeader(raw, "Content-Type")
+
+	// Extract headers
+	headers, _ := request["headers"].(map[string]any)
+	userAgent := extractHeaderArray(headers, "User-Agent")
+	referer := extractHeaderArray(headers, "Referer")
+
+	// Extract upstream info
+	upstream, hasUpstream := raw["upstream"].(map[string]any)
+	backendURL := ""
+	upstreamStatus := 0
+	upstreamResponseTimeMs := 0.0
+	if hasUpstream {
+		backendURL = getStringFromMap(upstream, "address")
+		upstreamStatus = getIntFromMap(upstream, "status")
+		upstreamDuration := getFloat64FromMap(upstream, "duration")
+		upstreamResponseTimeMs = upstreamDuration * 1000
+	}
+
+	// Extract logger name (can be used as RouterName)
+	loggerName := getString(raw, "logger")
+
+	// Extract user_id if present
+	userID := getString(raw, "user_id")
+
+	// Extract bytes_read
+	bytesRead := getInt64(raw, "bytes_read")
+
+	// Build event
+	event := &CaddyRequestEvent{
+		Timestamp:  timestamp,
+		SourceName: "", // Set by processor
+
+		ClientIP:   clientIP,
+		ClientPort: clientPort,
+		ClientUser: userID,
+
+		Method:        method,
+		Protocol:      protocol,
+		Host:          host,
+		Path:          path,
+		QueryString:   queryString,
+		RequestLength: bytesRead,
+		RequestScheme: requestScheme,
+
+		StatusCode:          statusCode,
+		ResponseSize:        responseSize,
+		ResponseTimeMs:      responseTimeMs,
+		ResponseContentType: responseContentType,
+
+		Duration:               int64(duration * 1e9), // Convert to nanoseconds
+		StartUTC:               timestamp.Format(time.RFC3339Nano),
+		UpstreamResponseTimeMs: upstreamResponseTimeMs,
+
+		UserAgent: userAgent,
+		Referer:   referer,
+
+		BackendURL:     backendURL,
+		RouterName:     loggerName,
+		UpstreamStatus: upstreamStatus,
+
+		TLSVersion:    tlsVersion,
+		TLSCipher:     tlsCipher,
+		TLSServerName: tlsServerName,
+	}
+
+	return event, nil
+}
+
+// Helper functions
+
+// parseUnixTimestamp converts a Unix timestamp (float) to time.Time
+func parseUnixTimestamp(ts float64) time.Time {
+	sec := int64(ts)
+	nsec := int64((ts - float64(sec)) * 1e9)
+	return time.Unix(sec, nsec)
+}
+
+// splitURI splits a URI into path and query string
+func splitURI(uri string) (path, query string) {
+	if idx := strings.Index(uri, "?"); idx != -1 {
+		return uri[:idx], uri[idx+1:]
+	}
+	return uri, ""
+}
+
+// convertTLSVersion converts TLS version code to string
+func convertTLSVersion(version int) string {
+	switch version {
+	case 769:
+		return "1.0"
+	case 770:
+		return "1.1"
+	case 771:
+		return "1.2"
+	case 772:
+		return "1.3"
+	default:
+		if version > 0 {
+			return fmt.Sprintf("UNKNOWN_%d", version)
+		}
+		return ""
+	}
+}
+
+// convertTLSCipher converts TLS cipher suite code to string
+func convertTLSCipher(cipher int) string {
+	// Map common cipher suites
+	cipherMap := map[int]string{
+		// TLS 1.3 cipher suites
+		4865: "TLS_AES_128_GCM_SHA256",
+		4866: "TLS_AES_256_GCM_SHA384",
+		4867: "TLS_CHACHA20_POLY1305_SHA256",
+		// TLS 1.2 cipher suites (common ones)
+		49195: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		49199: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		49200: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		49196: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+		52392: "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+		52393: "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+	}
+
+	if name, ok := cipherMap[cipher]; ok {
+		return name
+	}
+
+	if cipher > 0 {
+		return fmt.Sprintf("UNKNOWN_%d", cipher)
+	}
+	return ""
+}
+
+// extractHeaderArray extracts a header value from an array
+func extractHeaderArray(headers map[string]any, name string) string {
+	if headers == nil {
+		return ""
+	}
+
+	headerValue, ok := headers[name].([]any)
+	if !ok || len(headerValue) == 0 {
+		return ""
+	}
+
+	value, _ := headerValue[0].(string)
+	return value
+}
+
+// extractResponseHeader extracts a response header value
+func extractResponseHeader(raw map[string]any, name string) string {
+	respHeaders, ok := raw["resp_headers"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	return extractHeaderArray(respHeaders, name)
+}
+
+// Type-safe extraction helpers
+
+func getString(m map[string]any, key string) string {
+	if val, ok := m[key].(string); ok {
+		return val
+	}
+	return ""
+}
+
+func getStringFromMap(m map[string]any, key string) string {
+	if val, ok := m[key].(string); ok {
+		return val
+	}
+	return ""
+}
+
+func getInt(m map[string]any, key string) int {
+	switch val := m[key].(type) {
+	case int:
+		return val
+	case float64:
+		return int(val)
+	case string:
+		if i, err := strconv.Atoi(val); err == nil {
+			return i
+		}
+	}
+	return 0
+}
+
+func getIntFromMap(m map[string]any, key string) int {
+	switch val := m[key].(type) {
+	case int:
+		return val
+	case float64:
+		return int(val)
+	case string:
+		if i, err := strconv.Atoi(val); err == nil {
+			return i
+		}
+	}
+	return 0
+}
+
+func getInt64(m map[string]any, key string) int64 {
+	switch val := m[key].(type) {
+	case int64:
+		return val
+	case int:
+		return int64(val)
+	case float64:
+		return int64(val)
+	case string:
+		if i, err := strconv.ParseInt(val, 10, 64); err == nil {
+			return i
+		}
+	}
+	return 0
+}
+
+func getFloat64(m map[string]any, key string) float64 {
+	switch val := m[key].(type) {
+	case float64:
+		return val
+	case int:
+		return float64(val)
+	case string:
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			return f
+		}
+	}
+	return 0
+}
+
+func getFloat64FromMap(m map[string]any, key string) float64 {
+	switch val := m[key].(type) {
+	case float64:
+		return val
+	case int:
+		return float64(val)
+	case string:
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			return f
+		}
+	}
+	return 0
+}

--- a/internal/parser/caddy/parser_test.go
+++ b/internal/parser/caddy/parser_test.go
@@ -1,0 +1,334 @@
+package caddy
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pterm/pterm"
+)
+
+func TestParser_Name(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	if parser.Name() != "caddy" {
+		t.Errorf("Expected parser name 'caddy', got '%s'", parser.Name())
+	}
+}
+
+func TestParser_CanParse_ValidCaddyJSON(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	validLog := `{"level":"info","ts":1767690562.5659065,"logger":"http.log.access.log9","msg":"handled request","request":{"remote_ip":"192.168.1.100","method":"GET","uri":"/"},"status":200}`
+
+	if !parser.CanParse(validLog) {
+		t.Error("Expected parser to accept valid Caddy JSON log")
+	}
+}
+
+func TestParser_CanParse_InvalidJSON(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	invalidLog := `not a json log`
+
+	if parser.CanParse(invalidLog) {
+		t.Error("Expected parser to reject invalid JSON")
+	}
+}
+
+func TestParser_CanParse_NonCaddyJSON(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	nonCaddyLog := `{"timestamp":"2024-01-01","message":"some log"}`
+
+	if parser.CanParse(nonCaddyLog) {
+		t.Error("Expected parser to reject non-Caddy JSON")
+	}
+}
+
+func TestParser_Parse_FullCaddyLog(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	caddyLog := `{"level":"info","ts":1767690562.5659065,"logger":"http.log.access.log9","msg":"handled request","request":{"remote_ip":"100.200.300.172","remote_port":"49476","client_ip":"100.200.300.172","proto":"HTTP/2.0","method":"GET","host":"test.example.org","uri":"/api/users?page=1","headers":{"Te":["trailers"],"Cache-Control":["no-cache"],"User-Agent":["Mozilla/5.0 (X11; Linux x86_64; rv:146.0) Gecko/20100101 Firefox/146.0"],"Referer":["https://test.example.org/"]},"tls":{"resumed":false,"version":772,"cipher_suite":4865,"proto":"h2","server_name":"test.example.org"}},"bytes_read":1024,"user_id":"testuser","duration":0.00226026,"size":1546,"status":200,"resp_headers":{"Content-Type":["text/html"],"Server":["Apache/2.4.57 (Debian)"]}}`
+
+	event, err := parser.Parse(caddyLog)
+	if err != nil {
+		t.Fatalf("Failed to parse valid Caddy log: %v", err)
+	}
+
+	// Verify timestamp (with tolerance for float64 precision)
+	expectedTime := time.Unix(1767690562, 565906524) // Actual parsed value from 1767690562.5659065
+	if !event.Timestamp.Equal(expectedTime) {
+		t.Errorf("Expected timestamp %v, got %v", expectedTime, event.Timestamp)
+	}
+
+	// Verify client info
+	if event.ClientIP != "100.200.300.172" {
+		t.Errorf("Expected ClientIP '100.200.300.172', got '%s'", event.ClientIP)
+	}
+	if event.ClientPort != 49476 {
+		t.Errorf("Expected ClientPort 49476, got %d", event.ClientPort)
+	}
+	if event.ClientUser != "testuser" {
+		t.Errorf("Expected ClientUser 'testuser', got '%s'", event.ClientUser)
+	}
+
+	// Verify request info
+	if event.Method != "GET" {
+		t.Errorf("Expected Method 'GET', got '%s'", event.Method)
+	}
+	if event.Protocol != "HTTP/2.0" {
+		t.Errorf("Expected Protocol 'HTTP/2.0', got '%s'", event.Protocol)
+	}
+	if event.Host != "test.example.org" {
+		t.Errorf("Expected Host 'test.example.org', got '%s'", event.Host)
+	}
+	if event.Path != "/api/users" {
+		t.Errorf("Expected Path '/api/users', got '%s'", event.Path)
+	}
+	if event.QueryString != "page=1" {
+		t.Errorf("Expected QueryString 'page=1', got '%s'", event.QueryString)
+	}
+	if event.RequestScheme != "https" {
+		t.Errorf("Expected RequestScheme 'https', got '%s'", event.RequestScheme)
+	}
+	if event.RequestLength != 1024 {
+		t.Errorf("Expected RequestLength 1024, got %d", event.RequestLength)
+	}
+
+	// Verify response info
+	if event.StatusCode != 200 {
+		t.Errorf("Expected StatusCode 200, got %d", event.StatusCode)
+	}
+	if event.ResponseSize != 1546 {
+		t.Errorf("Expected ResponseSize 1546, got %d", event.ResponseSize)
+	}
+	if event.ResponseContentType != "text/html" {
+		t.Errorf("Expected ResponseContentType 'text/html', got '%s'", event.ResponseContentType)
+	}
+
+	// Verify timing
+	expectedDuration := int64(0.00226026 * 1e9)
+	if event.Duration != expectedDuration {
+		t.Errorf("Expected Duration %d, got %d", expectedDuration, event.Duration)
+	}
+
+	// Verify headers
+	if !strings.Contains(event.UserAgent, "Mozilla/5.0") {
+		t.Errorf("Expected UserAgent to contain 'Mozilla/5.0', got '%s'", event.UserAgent)
+	}
+	if event.Referer != "https://test.example.org/" {
+		t.Errorf("Expected Referer 'https://test.example.org/', got '%s'", event.Referer)
+	}
+
+	// Verify TLS info
+	if event.TLSVersion != "1.3" {
+		t.Errorf("Expected TLSVersion '1.3', got '%s'", event.TLSVersion)
+	}
+	if event.TLSCipher != "TLS_AES_128_GCM_SHA256" {
+		t.Errorf("Expected TLSCipher 'TLS_AES_128_GCM_SHA256', got '%s'", event.TLSCipher)
+	}
+	if event.TLSServerName != "test.example.org" {
+		t.Errorf("Expected TLSServerName 'test.example.org', got '%s'", event.TLSServerName)
+	}
+
+	// Verify logger name
+	if event.RouterName != "http.log.access.log9" {
+		t.Errorf("Expected RouterName 'http.log.access.log9', got '%s'", event.RouterName)
+	}
+}
+
+func TestParser_Parse_WithUpstream(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	caddyLog := `{"level":"info","ts":1767690562.5659065,"logger":"http.log.access","msg":"handled request","request":{"remote_ip":"192.168.1.100","method":"GET","uri":"/"},"status":200,"size":100,"duration":0.1,"upstream":{"address":"localhost:8080","duration":0.08,"status":200}}`
+
+	event, err := parser.Parse(caddyLog)
+	if err != nil {
+		t.Fatalf("Failed to parse Caddy log with upstream: %v", err)
+	}
+
+	if event.BackendURL != "localhost:8080" {
+		t.Errorf("Expected BackendURL 'localhost:8080', got '%s'", event.BackendURL)
+	}
+	if event.UpstreamStatus != 200 {
+		t.Errorf("Expected UpstreamStatus 200, got %d", event.UpstreamStatus)
+	}
+	if event.UpstreamResponseTimeMs != 80.0 {
+		t.Errorf("Expected UpstreamResponseTimeMs 80.0, got %f", event.UpstreamResponseTimeMs)
+	}
+}
+
+func TestParser_Parse_WithoutTLS(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	caddyLog := `{"level":"info","ts":1767690562.5659065,"logger":"http.log.access","msg":"handled request","request":{"remote_ip":"192.168.1.100","method":"GET","uri":"/","proto":"HTTP/1.1"},"status":200,"size":100,"duration":0.1}`
+
+	event, err := parser.Parse(caddyLog)
+	if err != nil {
+		t.Fatalf("Failed to parse Caddy log without TLS: %v", err)
+	}
+
+	if event.RequestScheme != "http" {
+		t.Errorf("Expected RequestScheme 'http' for non-TLS request, got '%s'", event.RequestScheme)
+	}
+	if event.TLSVersion != "" {
+		t.Errorf("Expected empty TLSVersion, got '%s'", event.TLSVersion)
+	}
+}
+
+func TestParser_Parse_URISplitting(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	testCases := []struct {
+		uri           string
+		expectedPath  string
+		expectedQuery string
+	}{
+		{"/", "/", ""},
+		{"/api/users", "/api/users", ""},
+		{"/api/users?page=1", "/api/users", "page=1"},
+		{"/search?q=test&lang=en", "/search", "q=test&lang=en"},
+	}
+
+	for _, tc := range testCases {
+		caddyLog := `{"level":"info","ts":1767690562.5659065,"logger":"http.log.access","msg":"handled request","request":{"remote_ip":"192.168.1.100","method":"GET","uri":"` + tc.uri + `"},"status":200,"size":100,"duration":0.1}`
+
+		event, err := parser.Parse(caddyLog)
+		if err != nil {
+			t.Fatalf("Failed to parse Caddy log with URI '%s': %v", tc.uri, err)
+		}
+
+		if event.Path != tc.expectedPath {
+			t.Errorf("For URI '%s': expected Path '%s', got '%s'", tc.uri, tc.expectedPath, event.Path)
+		}
+		if event.QueryString != tc.expectedQuery {
+			t.Errorf("For URI '%s': expected QueryString '%s', got '%s'", tc.uri, tc.expectedQuery, event.QueryString)
+		}
+	}
+}
+
+func TestParser_Parse_TLSVersionConversion(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	_ = NewParser(logger)
+
+	testCases := []struct {
+		version  int
+		expected string
+	}{
+		{769, "1.0"},
+		{770, "1.1"},
+		{771, "1.2"},
+		{772, "1.3"},
+		{999, "UNKNOWN_999"},
+	}
+
+	for _, tc := range testCases {
+		result := convertTLSVersion(tc.version)
+		if result != tc.expected {
+			t.Errorf("For TLS version %d: expected '%s', got '%s'", tc.version, tc.expected, result)
+		}
+	}
+}
+
+func TestParser_Parse_TLSCipherConversion(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	_ = NewParser(logger)
+
+	testCases := []struct {
+		cipher   int
+		expected string
+	}{
+		{4865, "TLS_AES_128_GCM_SHA256"},
+		{4866, "TLS_AES_256_GCM_SHA384"},
+		{4867, "TLS_CHACHA20_POLY1305_SHA256"},
+		{49195, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"},
+		{99999, "UNKNOWN_99999"},
+	}
+
+	for _, tc := range testCases {
+		result := convertTLSCipher(tc.cipher)
+		if result != tc.expected {
+			t.Errorf("For TLS cipher %d: expected '%s', got '%s'", tc.cipher, tc.expected, result)
+		}
+	}
+}
+
+func TestParser_Parse_ClientIPFallback(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	// Test with only remote_ip
+	caddyLog := `{"level":"info","ts":1767690562.5659065,"logger":"http.log.access","msg":"handled request","request":{"remote_ip":"192.168.1.100","method":"GET","uri":"/"},"status":200,"size":100,"duration":0.1}`
+	event, err := parser.Parse(caddyLog)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+	if event.ClientIP != "192.168.1.100" {
+		t.Errorf("Expected ClientIP '192.168.1.100', got '%s'", event.ClientIP)
+	}
+
+	// Test with X-Forwarded-For
+	caddyLog = `{"level":"info","ts":1767690562.5659065,"logger":"http.log.access","msg":"handled request","request":{"remote_ip":"10.0.0.1","method":"GET","uri":"/","headers":{"X-Forwarded-For":["203.0.113.1"]}},"status":200,"size":100,"duration":0.1}`
+	event, err = parser.Parse(caddyLog)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+	// Should prefer remote_ip over X-Forwarded-For
+	if event.ClientIP != "10.0.0.1" {
+		t.Errorf("Expected ClientIP '10.0.0.1', got '%s'", event.ClientIP)
+	}
+}
+
+func TestParser_Parse_MissingTimestamp(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	caddyLog := `{"level":"info","logger":"http.log.access","msg":"handled request","request":{"remote_ip":"192.168.1.100","method":"GET","uri":"/"},"status":200}`
+
+	_, err := parser.Parse(caddyLog)
+	if err == nil {
+		t.Error("Expected error for missing timestamp")
+	}
+}
+
+func TestParser_Parse_MissingRequest(t *testing.T) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	parser := NewParser(logger)
+
+	caddyLog := `{"level":"info","ts":1767690562.5659065,"logger":"http.log.access","msg":"handled request","status":200}`
+
+	_, err := parser.Parse(caddyLog)
+	if err == nil {
+		t.Error("Expected error for missing request object")
+	}
+}
+
+func TestParser_GetTimestamp(t *testing.T) {
+	expectedTime := time.Now()
+	event := &CaddyRequestEvent{
+		Timestamp: expectedTime,
+	}
+
+	if !event.GetTimestamp().Equal(expectedTime) {
+		t.Errorf("Expected timestamp %v, got %v", expectedTime, event.GetTimestamp())
+	}
+}
+
+func TestParser_GetSourceName(t *testing.T) {
+	event := &CaddyRequestEvent{
+		SourceName: "test-source",
+	}
+
+	if event.GetSourceName() != "test-source" {
+		t.Errorf("Expected source name 'test-source', got '%s'", event.GetSourceName())
+	}
+}

--- a/internal/parser/registry.go
+++ b/internal/parser/registry.go
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2026 Kolin
+// # Copyright (c) 2026 Kolin
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,11 +19,11 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-//
 package parsers
 
 import (
 	"fmt"
+	"loglynx/internal/parser/caddy"
 	"loglynx/internal/parser/traefik"
 
 	"github.com/pterm/pterm"
@@ -45,6 +45,16 @@ func (w *traefikParserWrapper) Parse(line string) (Event, error) {
 	return w.Parser.Parse(line)
 }
 
+// caddyParserWrapper wraps caddy.Parser to implement LogParser interface
+type caddyParserWrapper struct {
+	*caddy.Parser
+}
+
+// Parse adapts caddy.Parser.Parse to return Event interface
+func (w *caddyParserWrapper) Parse(line string) (Event, error) {
+	return w.Parser.Parse(line)
+}
+
 // NewRegistry creates a new parser registry with all built-in parsers
 func NewRegistry(logger *pterm.Logger) *Registry {
 	registry := &Registry{
@@ -56,6 +66,10 @@ func NewRegistry(logger *pterm.Logger) *Registry {
 	traefikParser := traefik.NewParser(logger)
 	registry.Register("traefik", &traefikParserWrapper{traefikParser})
 	logger.Debug("Registered parser", logger.Args("type", "traefik"))
+
+	caddyParser := caddy.NewParser(logger)
+	registry.Register("caddy", &caddyParserWrapper{caddyParser})
+	logger.Debug("Registered parser", logger.Args("type", "caddy"))
 
 	return registry
 }


### PR DESCRIPTION
- Updated .env.example to include CADDY_LOG_PATH for Caddy access log configuration.
- Enhanced README.md to reflect support for Caddy, including setup guide and log format details.
- Implemented Caddy log detection in internal/discovery/caddy.go.
- Created Caddy log parser in internal/parser/caddy with associated models and tests.
- Modified internal/parser/registry.go to register the Caddy parser.
- Updated config.go to include Caddy log path in configuration.
- Enhanced discovery engine to support Caddy log sources.